### PR TITLE
A `piped-input-stream` that doesn't swallow exceptions.

### DIFF
--- a/src/documint/util.clj
+++ b/src/documint/util.clj
@@ -65,3 +65,24 @@
        (sequential? v) (map f v)
        :else           (f v)))
    m))
+
+
+(defn piped-input-stream
+  "Create an input stream, returned as a Manifold deferred, from a function that
+  takes an output stream.
+
+  The function will be executed on a separate thread, and the stream
+  automatically closed after it finishes.
+
+  This is a variation on `ring.util.io/piped-input-stream`, notably exceptions
+  are not silently swallowed by `future`."
+  [func]
+  (let [input  (java.io.PipedInputStream.)
+        output (java.io.PipedOutputStream.)]
+    (.connect input output)
+    (-> (future
+          (try
+            (func output)
+            (finally (.close output)))
+          input)
+        (d/catch java.util.concurrent.ExecutionException #(throw (.getCause %))))))

--- a/test/documint/util_test.clj
+++ b/test/documint/util_test.clj
@@ -21,3 +21,24 @@
   (testing "nested map"
     (is (= (util/transform-map inc {:a {:b 1}})
            {:a {:b 2}}))))
+
+
+(deftest piped-input-stream
+  "Tests for `documint.util/piped-input-stream."
+  (testing "success"
+    (let [f (util/piped-input-stream
+             (fn [output]
+               (spit output "hello")))]
+      (is (= (slurp @f)
+             "hello"))))
+
+  (testing "failure"
+    (let [f (util/piped-input-stream
+             (fn [output]
+               (throw (ex-info "Bad stuff" {:cause :bad-stuff}))))]
+      (is (thrown? clojure.lang.ExceptionInfo @f))
+      (try
+        @f
+        (catch clojure.lang.ExceptionInfo e
+          (is (= (ex-data e)
+                 {:cause :bad-stuff})))))))


### PR DESCRIPTION
Fixes #3.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fusionapp/clj-documint/17)
<!-- Reviewable:end -->
