### PR TITLE
Reset the graphics context for the stamp content stream.

### DIFF
--- a/src/documint/pdf/stamp.clj
+++ b/src/documint/pdf/stamp.clj
@@ -44,7 +44,7 @@
                         (.translate (- dw sw) (- (+ sh (- dh sh))))))
       (case align
         :bottom-right (doto transform
-                        (.translate (- dw sw) (- dh sh)))))
+                        (.translate (- dw sw) (min 0 (- dh sh))))))
     ;; This means the page is upside down, correct for this by rotating another
     ;; 180 degrees.
     (when (>= rot 180)

--- a/src/documint/pdf/stamp.clj
+++ b/src/documint/pdf/stamp.clj
@@ -70,7 +70,9 @@
     (with-open [stream (PDPageContentStream. document
                                              page
                                              PDPageContentStream$AppendMode/APPEND
-                                             true)]
+                                             true ;; Compress?
+                                             true ;; Reset context?
+                                             )]
       (doto stream
         (.beginMarkedContent COSName/OC layer)
         (.saveGraphicsState)


### PR DESCRIPTION
Apparently this fixes weird cases where the stamp is not visible.

Fixes #75.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fusionapp/clj-documint/76)
<!-- Reviewable:end -->
