### PR TITLE
Fix boot reloading workflow.

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -40,7 +40,7 @@
   []
   (comp
    (watch :verbose true)
-   (system :sys #'dev-system :auto true)
+   (system :sys #'dev-system :auto true :files ["clj$"] :regexes true)
    (repl :server true)))
 
 


### PR DESCRIPTION
From some version (0.3?) restarting only happens when matching files are
changed, since we were providing no matching files only namespace reloading (?)
was taking place; which is insufficient for our purposes.

Fixes #82.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fusionapp/clj-documint/83)
<!-- Reviewable:end -->
