### PR TITLE
Only decrement the `:documint/sessions-active-total` metric when a session is actually destroyed.

### DIFF
--- a/src/documint/util.clj
+++ b/src/documint/util.clj
@@ -109,3 +109,15 @@
                      (resolve '~expr)
                      (resolve (first '~expr)))]
        [(/ (double (- (. System (nanoTime)) start#)) 1000000.0) return#])))
+
+
+(defn swap-vals!
+  "Like swap-vals! in Clojure 1.9."
+  [atom f & args]
+  (let [m       (volatile! nil)
+        new-val (apply swap! atom
+                       (fn [val & args]
+                         (vreset! m val)
+                         (apply f val args))
+                       args)]
+    [@m new-val]))


### PR DESCRIPTION
Fixes #84.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fusionapp/clj-documint/85)
<!-- Reviewable:end -->
