### PR TITLE
Try detect (and then ignore) corrupt optional content groups when stamping documents.

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -17,7 +17,7 @@
                  [compojure "1.6.0"]
                  [environ "1.1.0"]
                  [manifold "0.1.6"]
-                 [org.apache.pdfbox/pdfbox "2.0.8"]
+                 [org.apache.pdfbox/pdfbox "2.0.9"]
                  [org.bouncycastle/bcpkix-jdk15on "1.58"]
                  [org.bouncycastle/bcprov-jdk15on "1.58"]
                  [prismatic/schema "1.1.7"]

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                  [compojure "1.6.0"]
                  [environ "1.1.0"]
                  [manifold "0.1.6"]
-                 [org.apache.pdfbox/pdfbox "2.0.8"]
+                 [org.apache.pdfbox/pdfbox "2.0.9"]
                  [org.bouncycastle/bcpkix-jdk15on "1.58"]
                  [org.bouncycastle/bcprov-jdk15on "1.58"]
                  [prismatic/schema "1.1.7"]


### PR DESCRIPTION
Fixes #88.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fusionapp/clj-documint/89)
<!-- Reviewable:end -->
