### PR TITLE
Convert validation failure errors to strings.

### DIFF
--- a/src/documint/actions.clj
+++ b/src/documint/actions.clj
@@ -72,7 +72,7 @@
              (if (= (:type data) :schema.core/error)
                (ex-info "Schema validation failure"
                         {:causes [[:validation-failure
-                                   (select-keys data [:error])]]})
+                                   {:error (prn-str (:error data))}]]})
                e))))))
     (throw (ex-info "Unknown action"
                     {:causes [[:unknown-action action-name]]}))))


### PR DESCRIPTION
This avoids trying to JSON serialize objects that have no natural JSON representation.

Fixes #80.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fusionapp/clj-documint/105)
<!-- Reviewable:end -->
