### PR TITLE
Remove unused `:truststore` component from the system map.

### DIFF
--- a/src/documint/systems.clj
+++ b/src/documint/systems.clj
@@ -32,7 +32,6 @@
     (System/setProperty "org.apache.pdfbox.rendering.UsePureJavaCMYKConversion" "true")
     (component/system-map
      :keystore               keystore
-     :truststore             truststore
      :session-factory        (temp-file-session-factory)
      :renderer/flying-saucer (saucer/renderer (conf [:renderer] {}))
      :renderer/fop           (fop/renderer (conf [:renderer-fop] {}))


### PR DESCRIPTION
Fixes #119.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fusionapp/clj-documint/120)
<!-- Reviewable:end -->
