### PR TITLE
Make configuration validation more lenient.

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -19,14 +19,29 @@
   * Copy `documint.config.json.example` to `documint.config.json` and adjust the
     configuration to suit your environment. (See below for setting up the keystore
     and truststore if necessary.)
+  * If setting up document signing, create a self-signed certificate for signing:
+  
+    ```
+    $ keytool -genkey \
+              -keyalg RSA \
+              -alias selfsigned \
+              -keystore documint_keystore_dev.jks \
+              -validity 3650 \
+              -keysize 2048
+    ```
+    
+    Then reference this certificate by its alias (`selfsigned` in this case) in
+    the `signing` stanza of the configuration.
   * Run `boot dev` to run the hot-reloading development version of the service.
+    (It's possible to use `lein run` and forego hot-reloading in order to avoid
+    depending on Boot.)
   
     Any dependencies will be downloaded by boot and afterwards the service should
     be running:
   
     ```
-    2018-06-20 22:41:41.284:INFO:oejs.ServerConnector:clojure-agent-send-off-pool-0: Started ServerConnector@2034342c{HTTP/1.1}{0.0.0.0:3001}
-    2018-06-20 22:41:41.403:INFO:oejs.ServerConnector:clojure-agent-send-off-pool-0: Started ServerConnector@2efbf813{SSL-http/1.1}{0.0.0.0:3002}
+    2018-06-20 22:41:41.284:INFO:oejs.ServerConnector:clojure-agent-send-off-pool-0: Started ServerConnector@2034342c{HTTP/1.1}{0.0.0.0:3000}
+    2018-06-20 22:41:41.403:INFO:oejs.ServerConnector:clojure-agent-send-off-pool-0: Started ServerConnector@2efbf813{SSL-http/1.1}{0.0.0.0:3001}
     Starting #'documint.systems/dev-system
     nREPL server started on port 60120 on host 127.0.0.1 - nrepl://127.0.0.1:60120
     Elapsed time: 4.072 sec
@@ -35,12 +50,12 @@
     At this stage it should be possible to interact with the service:
   
     ```
-    $ curl -s -L --data '' http://localhost:3001/sessions/ | python -m json.tool
+    $ curl -s -L --data '' http://localhost:3000/sessions/ | python -m json.tool
     {
       "links": {
-        "self": "http://localhost:3001/sessions/90a1c5fc-e295-458d-82fa-3e65038fc690",
-        "perform": "http://localhost:3001/sessions/90a1c5fc-e295-458d-82fa-3e65038fc690/perform",
-        "store-content": "http://localhost:3001/sessions/90a1c5fc-e295-458d-82fa-3e65038fc690/contents/"
+        "self": "http://localhost:3000/sessions/90a1c5fc-e295-458d-82fa-3e65038fc690",
+        "perform": "http://localhost:3000/sessions/90a1c5fc-e295-458d-82fa-3e65038fc690/perform",
+        "store-content": "http://localhost:3000/sessions/90a1c5fc-e295-458d-82fa-3e65038fc690/contents/"
       }
     }
     ```
@@ -63,9 +78,7 @@ Documint can do client-certification authentication and SSL itself if necessary:
               -validity 3650 \
               -keysize 2048
     ```
-  
   * Obtain a CA certificate. For development purposes the [snake oil CA cert from Fusion](https://raw.githubusercontent.com/fusionapp/fusion/master/fusion/test/services/data/snake-oil-ca.crt.pem) is sufficient.
-  
   * Add the CA cert to a truststore, any client requests containing a cert signed
     by this CA will be accepted:
   

--- a/src/documint/config.clj
+++ b/src/documint/config.clj
@@ -15,13 +15,16 @@
   {:web-server     {(s/optional-key :port)     s/Int
                     (s/optional-key :tls-port) s/Int
                     (s/optional-key :tls-cert) s/Str}
-   :keystore       {:path     path-exists?
+   (s/optional-key
+    :keystore)     {:path     path-exists?
                     :password s/Str}
    (s/optional-key
     :truststore)   {:path     path-exists?
                     :password s/Str}
-   :signing        {:certificate-passwords {s/Keyword s/Str}}
-   :renderer       {(s/optional-key :font-path) path-exists?
+   (s/optional-key
+    :signing)      {:certificate-passwords {s/Keyword s/Str}}
+   (s/optional-key
+    :renderer)     {(s/optional-key :font-path) path-exists?
                     (s/optional-key :logging?)  s/Bool}
    (s/optional-key
     :renderer-fop) {(s/optional-key :xconf)    path-exists?

--- a/src/documint/pdf/signing.clj
+++ b/src/documint/pdf/signing.clj
@@ -135,6 +135,7 @@
 
 (defn signer-component
   "Create a `SignerComponent`."
-  [certificate-passwords]
+  [keystore certificate-passwords]
   (map->SignerComponent
-   {:certificate-passwords certificate-passwords}))
+   {:keystore              keystore
+    :certificate-passwords certificate-passwords}))


### PR DESCRIPTION
And allow `keystore` to be nil, although operations that try to use it might just NPE.

Also improve the documentation around setting up the signing certificate.

Fixes #121.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fusionapp/clj-documint/122)
<!-- Reviewable:end -->
